### PR TITLE
Fix 5.1 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Bump version
         uses: php-actions/composer@v5
         with:
-          command: bump -- ${{ github.event.inputs.newVersion }}
+          command: version-bump -- ${{ github.event.inputs.newVersion }}
       - uses: EndBug/add-and-commit@v7
         with:
           add: 'composer.json'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,19 +17,18 @@ jobs:
         with:
           token: ${{ secrets.REPO_TOKEN }}
       - name: Install dependencies
-        uses: php-actions/composer@v5
+        uses: php-actions/composer@v6
       - name: Bump version
-        uses: php-actions/composer@v5
+        uses: php-actions/composer@v6
         with:
           command: version-bump -- ${{ github.event.inputs.newVersion }}
-      - uses: EndBug/add-and-commit@v7
+      - uses: EndBug/add-and-commit@v9
         with:
           add: 'composer.json'
           author_name: 'JobRouterBot'
           author_email: 'opensource@jobrouter.com'
           message: 'Bump version to ${{ github.event.inputs.newVersion }}'
-          pull_strategy: 'NO-PULL'
           push: true
           remove: ''
-          signoff: true
+          commit: --signoff
           tag: 'v${{ github.event.inputs.newVersion }}'

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,6 @@
         "ext-json": "*"
     },
     "scripts": {
-        "bump": "php version-bump.php"
+        "version-bump": "php version-bump.php"
     }
 }


### PR DESCRIPTION
Composer now have it's built-in `bump` command, conflicting the self-written one. 
This is a good chance to update the versions of the used GitHub actions.